### PR TITLE
Enable Docker extension inside devcontainer. Make it working with Podman.

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -35,6 +35,8 @@ ENV _CONTAINERS_USERNS_CONFIGURED=""
 
 # Socket path for podman
 ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/podman/podman.sock
 
 USER ${USER_NAME}
-CMD ["sleep", "infinity"]
+
+CMD ["podman", "system", "service", "--time", "0"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,4 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+// For format details, see https://aka.ms/devcontainer.json.
 {
 	"name": "Outbox-Flow Devcontainer",
 	"build": {
@@ -71,10 +70,14 @@
 				// Management tool for postgres and kafka
 				"cweijan.vscode-postgresql-client2",
 				// Protobuf files support
-				"zxh404.vscode-proto3"
+				"zxh404.vscode-proto3",
+				// Docker (do not upgrade as later versions do not work with Podman for now)
+				"ms-azuretools.vscode-docker@1.22.2"
 			],
 			"settings": {
-				"extensions.ignoreRecommendations": true
+				"extensions.ignoreRecommendations": true,
+				"docker.dockerPath": "/usr/bin/podman",
+				"docker.composeCommand": "podman-compose"
 			}
 		}
 	},
@@ -85,5 +88,8 @@
 	],
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	"remoteUser": "${localEnv:USER:dev}"
+	"remoteUser": "${localEnv:USER:dev}",
+
+	// Tells VS Code not to override CMD and ENTRYPOINT properties defined in the Containerfile
+	"overrideCommand": false	
 }


### PR DESCRIPTION
This PR adds Docker extension to the devcontainer and configures it to work with Podman.
The change makes dev environment friendlier, as one can now see all running containers and existing images.
There are many other benefits, for example it is possible to start Kafka and Postgres by just selecting "Compose Up" option from the context menu on the scripts/docker-compose.yml file.